### PR TITLE
Add Turkish language support

### DIFF
--- a/custom_components/tcl_home_unofficial/translations/tr.json
+++ b/custom_components/tcl_home_unofficial/translations/tr.json
@@ -8,7 +8,7 @@
             "invalid_auth": "Geçersiz kimlik doğrulama",
             "unknown": "Beklenmeyen hata"
         },
-        "flow_title": "TCL Home uygulaması - Resmi Olmayan (flow_title)",
+        "flow_title": "TCL Home uygulaması - Resmi Olmayan",
         "step": {
             "settings_of_app": {
                 "data": {


### PR DESCRIPTION
Added Turkish (tr) translation file for the Home Assistant integration. This includes translations for config flow, options flow, error messages, and all UI strings.