### PR TITLE
Add support for device: Cylindrical AC

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Breeva Air Purifier A2 (by Ajsalemo)
 - Breeva Air Purifier A3 (by Ajsalemo)
 - Breeva Air Purifier A5 (by Ajsalemo)
+- Cylindrical AC 
 
 ## Notes by device types
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Breeva Air Purifier A2 (by Ajsalemo)
 - Breeva Air Purifier A3 (by Ajsalemo)
 - Breeva Air Purifier A5 (by Ajsalemo)
-- Cylindrical AC 
+- Cylindrical AC
 
 ## Notes by device types
 

--- a/custom_components/tcl_home_unofficial/climate.py
+++ b/custom_components/tcl_home_unofficial/climate.py
@@ -113,6 +113,7 @@ async def async_setup_entry(
                     device=device,
                     type="SplitAc"
                     if device.device_type == DeviceTypeEnum.SPLIT_AC
+                    or device.device_type == DeviceTypeEnum.CYLINDRICAL_AC
                     else "ClimateControll",
                     name="Climate",
                     power_switch_feature=DeviceFeatureEnum.SWITCH_POWER,

--- a/custom_components/tcl_home_unofficial/device.py
+++ b/custom_components/tcl_home_unofficial/device.py
@@ -37,6 +37,9 @@ from .tcl_device_spit_ac_fresh_air import (
 from .tcl_device_window_ac import (TCL_WindowAC_DeviceData,
                                    get_stored_window_ac_data,
                                    handle_window_ac_mode_change)
+from .tcl_device_cylindrical_ac import (TCL_CylindricalAC_DeviceData,
+                                        get_stored_cylindrical_ac_data,
+                                        handle_cylindrical_ac_mode_change)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,6 +137,12 @@ class Device:
                         aws_thing_state=aws_thing["state"]["reported"],
                         delta=aws_thing["state"].get("delta", {}),
                     )
+                case DeviceTypeEnum.CYLINDRICAL_AC:
+                    self.data = TCL_CylindricalAC_DeviceData(
+                        device_id=self.device_id,
+                        aws_thing_state=aws_thing["state"]["reported"],
+                        delta=aws_thing["state"].get("delta", {}),
+                    )
                 case DeviceTypeEnum.DEHUMIDIFIER_DEM:
                     self.data = TCL_Dehumidifier_DEM_DeviceData(
                         device_id=self.device_id,
@@ -188,6 +197,7 @@ class Device:
         | TCL_SplitAC_Fresh_Air_DeviceData
         | TCL_PortableAC_DeviceData
         | TCL_WindowAC_DeviceData
+        | TCL_CylindricalAC_DeviceData
         | TCL_Dehumidifier_DEM_DeviceData
         | TCL_Dehumidifier_DF_DeviceData
         | TCL_DuctAC_DeviceData
@@ -356,6 +366,8 @@ async def get_device_storage(hass: HomeAssistant, device: Device) -> None:
         return await get_stored_spit_ac_fresh_data(hass, device.device_id)
     elif device.device_type == DeviceTypeEnum.SPLIT_AC:
         return await get_stored_spit_ac_data(hass, device.device_id)
+    elif device.device_type == DeviceTypeEnum.CYLINDRICAL_AC:
+        return await get_stored_cylindrical_ac_data(hass, device.device_id)
     elif device.device_type == DeviceTypeEnum.DUCT_AC:
         return await get_stored_duct_ac_data(hass, device.device_id)
     elif device.device_type == DeviceTypeEnum.PORTABLE_AC:
@@ -387,6 +399,13 @@ def get_desired_state_for_mode_change(
         )
     elif device.device_type == DeviceTypeEnum.SPLIT_AC:
         desired_state = handle_split_ac_mode_change(
+            desired_state=desired_state,
+            value=value,
+            supported_features=device.supported_features,
+            stored_data=stored_data,
+        )
+    elif device.device_type == DeviceTypeEnum.CYLINDRICAL_AC:
+        desired_state = handle_cylindrical_ac_mode_change(
             desired_state=desired_state,
             value=value,
             supported_features=device.supported_features,

--- a/custom_components/tcl_home_unofficial/device_features.py
+++ b/custom_components/tcl_home_unofficial/device_features.py
@@ -188,6 +188,49 @@ def getSupportedFeatures(
                     features.append(DeviceFeatureEnum.SENSOR_SPLIT_AC_TVOC_VALUE)
 
                 return features
+            case DeviceTypeEnum.CYLINDRICAL_AC:
+                features = [
+                    DeviceFeatureEnum.INTERNAL_IS_AC,
+                    DeviceFeatureEnum.MODE_AC_AUTO,
+                    DeviceFeatureEnum.MODE_AC_COOL,
+                    DeviceFeatureEnum.MODE_AC_DEHUMIDIFICATION,
+                    DeviceFeatureEnum.MODE_AC_FAN,
+                    DeviceFeatureEnum.MODE_AC_HEAT,
+                    DeviceFeatureEnum.SENSOR_CURRENT_TEMPERATURE,
+                    DeviceFeatureEnum.SENSOR_IS_ONLINE,
+                    DeviceFeatureEnum.SWITCH_POWER,
+                    DeviceFeatureEnum.SWITCH_BEEP,
+                    DeviceFeatureEnum.SWITCH_HEALTHY,
+                    DeviceFeatureEnum.SWITCH_DRYING,
+                    DeviceFeatureEnum.SWITCH_SCREEN,
+                    DeviceFeatureEnum.SELECT_MODE,
+                    DeviceFeatureEnum.SELECT_VERTICAL_DIRECTION,
+                    DeviceFeatureEnum.SELECT_HORIZONTAL_DIRECTION,
+                    DeviceFeatureEnum.SELECT_SLEEP_MODE,
+                    DeviceFeatureEnum.NUMBER_TARGET_TEMPERATURE,
+                    DeviceFeatureEnum.CLIMATE,
+                    DeviceFeatureEnum.USER_CONFIG_BEHAVIOR_MEMORIZE_TEMP_BY_MODE,
+                    DeviceFeatureEnum.USER_CONFIG_BEHAVIOR_MEMORIZE_FAN_SPEED_BY_MODE,
+                    DeviceFeatureEnum.USER_CONFIG_BEHAVIOR_SILENT_BEEP_WHEN_TURN_ON,
+                ]
+                if has_power_consumption_data:
+                    features.append(DeviceFeatureEnum.SENSOR_POWER_CONSUMPTION_DAILY)
+                if has_work_time_data:
+                    features.append(DeviceFeatureEnum.SENSOR_WORK_TIME_DAILY)
+                if len(capabilities) > 0:
+                    if DeviceCapabilityEnum.CAPABILITY_GENERATOR_MODE in capabilities:
+                        features.append(DeviceFeatureEnum.SELECT_GENERATOR_MODE)
+                if has_property(aws_thing_state_reported, "windSpeed7Gear"):
+                    features.append(DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR)
+                if has_property(aws_thing_state_reported, "externalUnitTemperature"):
+                    features.append(DeviceFeatureEnum.SENSOR_EXTERNAL_UNIT_TEMPERATURE)
+                if has_property(aws_thing_state_reported, "AIECOSwitch"):
+                    features.append(DeviceFeatureEnum.SWITCH_AI_ECO)
+                if has_property(aws_thing_state_reported, "targetFahrenheitTemp"):
+                    features.append(DeviceFeatureEnum.INTERNAL_SET_TFT_WITH_TT)
+                if has_property(aws_thing_state_reported, "internalUnitCoilTemperature"):
+                    features.append(DeviceFeatureEnum.SENSOR_INTERNAL_UNIT_COIL_TEMPERATURE)
+                return features
             case DeviceTypeEnum.SPLIT_AC_FRESH_AIR:
                 features = [
                     DeviceFeatureEnum.INTERNAL_IS_AC,

--- a/custom_components/tcl_home_unofficial/device_types.py
+++ b/custom_components/tcl_home_unofficial/device_types.py
@@ -6,6 +6,7 @@ class DeviceTypeEnum(StrEnum):
     SPLIT_AC_FRESH_AIR = "Split AC Fresh air"
     PORTABLE_AC = "Portable AC"
     WINDOW_AC = "Window AC"
+    CYLINDRICAL_AC = "Cylindrical AC"          # <-- NEU
     DEHUMIDIFIER_DEM = "Dehumidifier DEM"
     DEHUMIDIFIER_DF = "Dehumidifier DF"
     DUCT_AC = "Duct"
@@ -29,6 +30,7 @@ def is_implemented_by_integration(device_type: str) -> bool:
         "Split AC Fresh air",
         "Portable AC",
         "Window AC",
+        "Cylindrical AC",                      # <-- NEU
         "Dehumidifier DEM",
         "Dehumidifier DF",
         "Duct",
@@ -56,6 +58,8 @@ def calculateDeviceType(device_type: str) -> DeviceTypeEnum | None:
         return DeviceTypeEnum.SPLIT_AC_FRESH_AIR
     elif device_type == "Window AC":
         return DeviceTypeEnum.WINDOW_AC
+    elif device_type == "Cylindrical AC":       # <-- NEU (VOR dem Split AC Check!)
+        return DeviceTypeEnum.CYLINDRICAL_AC
     elif device_type == "Duct":
         return DeviceTypeEnum.DUCT_AC
     elif device_type == "Split AC" or is_split_ac_with_number(device_type):

--- a/custom_components/tcl_home_unofficial/device_types.py
+++ b/custom_components/tcl_home_unofficial/device_types.py
@@ -58,7 +58,7 @@ def calculateDeviceType(device_type: str) -> DeviceTypeEnum | None:
         return DeviceTypeEnum.SPLIT_AC_FRESH_AIR
     elif device_type == "Window AC":
         return DeviceTypeEnum.WINDOW_AC
-    elif device_type == "Cylindrical AC":       # <-- NEU (VOR dem Split AC Check!)
+    elif device_type == "Cylindrical AC":       # Keep this before the Split AC check.
         return DeviceTypeEnum.CYLINDRICAL_AC
     elif device_type == "Duct":
         return DeviceTypeEnum.DUCT_AC

--- a/custom_components/tcl_home_unofficial/tcl_device_cylindrical_ac.py
+++ b/custom_components/tcl_home_unofficial/tcl_device_cylindrical_ac.py
@@ -1,0 +1,186 @@
+"""Cylindrical AC device data.
+
+This file defines how the integration reads and controls a Cylindrical AC unit.
+It maps the AWS IoT Thing State fields (from the TCL cloud API) to Python attributes,
+and handles mode-change logic (what state to send when the user switches modes).
+
+The field names (e.g. "powerSwitch", "windSpeed7Gear") come directly from the
+device's diagnostic data and must match the TCL API exactly.
+"""
+
+from dataclasses import dataclass
+
+from homeassistant.core import HomeAssistant
+
+from .calculations import try_get_value
+from .data_storage import get_stored_data, safe_set_value, set_stored_data, setup_common_init_values
+from .device_enums import ModeEnum
+from .device_features import DeviceFeatureEnum
+
+
+@dataclass
+class TCL_CylindricalAC_DeviceData:
+    """Parses the AWS Thing State for a Cylindrical AC device.
+
+    Each attribute corresponds to a key in the device's reported state.
+    The try_get_value function checks the 'delta' dict first (pending changes),
+    then falls back to 'aws_thing_state' (last known state), and finally
+    uses the default value if neither has the key.
+    """
+
+    def __init__(self, device_id: str, aws_thing_state: dict, delta: dict) -> None:
+        self.device_id = device_id
+
+        # --- Core controls ---
+        self.power_switch               = int(try_get_value(delta, aws_thing_state, "powerSwitch", -1))
+        self.work_mode                  = int(try_get_value(delta, aws_thing_state, "workMode", -1))
+        self.sleep                      = int(try_get_value(delta, aws_thing_state, "sleep", -1))
+
+        # --- Temperature ---
+        self.target_temperature         = int(try_get_value(delta, aws_thing_state, "targetTemperature", -1))
+        self.current_temperature        = int(try_get_value(delta, aws_thing_state, "currentTemperature", -1))
+        self.target_fahrenheit_temp     = int(try_get_value(delta, aws_thing_state, "targetFahrenheitTemp", -1))
+        self.temperature_type           = int(try_get_value(delta, aws_thing_state, "temperatureType", -1))
+        self.lower_temperature_limit    = int(try_get_value(delta, aws_thing_state, "lowerTemperatureLimit", 16))
+        self.upper_temperature_limit    = int(try_get_value(delta, aws_thing_state, "upperTemperatureLimit", 31))
+
+        # --- Fan / Wind ---
+        # Note: This device uses "windSpeed7Gear" (0-6) instead of "windSpeed" (0-2).
+        self.wind_speed_7_gear          = int(try_get_value(delta, aws_thing_state, "windSpeed7Gear", -1))
+        self.wind_speed_auto_switch     = int(try_get_value(delta, aws_thing_state, "windSpeedAutoSwitch", -1))
+
+        # --- Swing / Air direction ---
+        # Note: This device uses "verticalWind" / "horizontalWind" (on/off toggles)
+        # instead of "verticalSwitch" / "horizontalSwitch" found on standard Split ACs.
+        self.vertical_wind              = int(try_get_value(delta, aws_thing_state, "verticalWind", -1))
+        self.horizontal_wind            = int(try_get_value(delta, aws_thing_state, "horizontalWind", -1))
+        self.vertical_direction         = int(try_get_value(delta, aws_thing_state, "verticalDirection", -1))
+        self.horizontal_direction       = int(try_get_value(delta, aws_thing_state, "horizontalDirection", -1))
+
+        # --- Switches / Features ---
+        self.beep_switch                = int(try_get_value(delta, aws_thing_state, "beepSwitch", -1))
+        self.screen                     = int(try_get_value(delta, aws_thing_state, "screen", -1))
+        self.ai_eco                     = int(try_get_value(delta, aws_thing_state, "AIECOSwitch", -1))
+        self.healthy                    = int(try_get_value(delta, aws_thing_state, "healthy", -1))
+        self.anti_moldew                = int(try_get_value(delta, aws_thing_state, "antiMoldew", -1))
+        self.anti_direct_blow           = int(try_get_value(delta, aws_thing_state, "antiDirectBlow", -1))
+        self.generator_mode             = int(try_get_value(delta, aws_thing_state, "generatorMode", -1))
+
+        # --- Sensors / Diagnostics ---
+        self.internal_unit_coil_temperature = int(try_get_value(delta, aws_thing_state, "internalUnitCoilTemperature", -1))
+        self.external_unit_temperature      = int(try_get_value(delta, aws_thing_state, "externalUnitTemperature", -1))
+        self.self_clean_status              = int(try_get_value(delta, aws_thing_state, "selfCleanStatus", -1))
+        self.error_code                     = list(try_get_value(delta, aws_thing_state, "errorCode", []))
+
+    # --- Type annotations (required by the @dataclass decorator) ---
+    device_id: str
+    power_switch: int | bool
+    work_mode: int | bool
+    sleep: int | bool
+    target_temperature: int
+    current_temperature: int
+    target_fahrenheit_temp: int
+    temperature_type: int
+    lower_temperature_limit: int
+    upper_temperature_limit: int
+    wind_speed_7_gear: int
+    wind_speed_auto_switch: int
+    vertical_wind: int
+    horizontal_wind: int
+    vertical_direction: int
+    horizontal_direction: int
+    beep_switch: int | bool
+    screen: int | bool
+    ai_eco: int | bool
+    healthy: int | bool
+    anti_moldew: int | bool
+    anti_direct_blow: int | bool
+    generator_mode: int
+    internal_unit_coil_temperature: int
+    external_unit_temperature: int
+    self_clean_status: int
+    error_code: list[int]
+
+
+async def get_stored_cylindrical_ac_data(
+    hass: HomeAssistant, device_id: str
+) -> dict[str, any]:
+    """Initialize persisted settings with sensible defaults.
+
+    These stored values remember user preferences across restarts,
+    e.g. the last temperature set in each mode, or the fan speed per mode.
+    """
+    need_save = False
+    stored_data = await get_stored_data(hass, device_id)
+    if stored_data is None:
+        stored_data = {}
+        need_save = True
+
+    # Common init values shared across all device types
+    stored_data, need_save = setup_common_init_values(stored_data)
+
+    # Temperature step: 1°C increments (no 0.5° support on this device)
+    stored_data, need_save = safe_set_value(stored_data, "non_user_config.native_temp_step", 1.0)
+
+    # User-configurable behaviors (can be toggled via HA switches)
+    stored_data, need_save = safe_set_value(stored_data, "user_config.behavior.memorize_temp_by_mode", False)
+    stored_data, need_save = safe_set_value(stored_data, "user_config.behavior.memorize_fan_speed_by_mode", False)
+    stored_data, need_save = safe_set_value(stored_data, "user_config.behavior.silent_beep_when_turn_on", False)
+
+    # Default temperatures per mode
+    stored_data, need_save = safe_set_value(stored_data, "target_temperature.Cool.value", 24)
+    stored_data, need_save = safe_set_value(stored_data, "target_temperature.Heat.value", 24)
+    stored_data, need_save = safe_set_value(stored_data, "target_temperature.Dehumidification.value", 24)
+    stored_data, need_save = safe_set_value(stored_data, "target_temperature.Fan.value", 24)
+    stored_data, need_save = safe_set_value(stored_data, "target_temperature.Auto.value", 24)
+
+    # Default fan speed per mode
+    default_wind_speed = "Auto"
+    stored_data, need_save = safe_set_value(stored_data, "fan_speed.Cool.value", default_wind_speed)
+    stored_data, need_save = safe_set_value(stored_data, "fan_speed.Heat.value", default_wind_speed)
+    stored_data, need_save = safe_set_value(stored_data, "fan_speed.Dehumidification.value", default_wind_speed)
+    stored_data, need_save = safe_set_value(stored_data, "fan_speed.Fan.value", default_wind_speed)
+    stored_data, need_save = safe_set_value(stored_data, "fan_speed.Auto.value", default_wind_speed)
+
+    if need_save:
+        await set_stored_data(hass, device_id, stored_data)
+    return stored_data
+
+
+def handle_cylindrical_ac_mode_change(
+    desired_state: dict, value: ModeEnum,
+    supported_features: list[DeviceFeatureEnum], stored_data: dict
+) -> dict:
+    """Define what state changes to send when the user switches AC modes.
+
+    Each mode sets specific defaults for fan speed, temperature, etc.
+    The workMode integer value is already set by the caller via mode_enum_to_value_mapp.
+    This function adds mode-specific side effects.
+    """
+    match value:
+        case ModeEnum.AUTO:
+            # Auto mode: let the device decide fan speed
+            if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in supported_features:
+                desired_state["windSpeedAutoSwitch"] = 1
+                desired_state["windSpeed7Gear"] = 0
+        case ModeEnum.COOL:
+            # Cool mode: set target temperature from stored preferences
+            if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in supported_features:
+                desired_state["windSpeedAutoSwitch"] = 1
+                desired_state["windSpeed7Gear"] = 0
+        case ModeEnum.DEHUMIDIFICATION:
+            # Dehumidification: fixed fan speed, device controls temperature
+            if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in supported_features:
+                desired_state["windSpeed7Gear"] = 2
+                desired_state["windSpeedAutoSwitch"] = 0
+        case ModeEnum.FAN:
+            # Fan only: no compressor, auto fan speed
+            if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in supported_features:
+                desired_state["windSpeedAutoSwitch"] = 1
+                desired_state["windSpeed7Gear"] = 0
+        case ModeEnum.HEAT:
+            # Heat mode: similar to cool but with heating
+            if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in supported_features:
+                desired_state["windSpeedAutoSwitch"] = 1
+                desired_state["windSpeed7Gear"] = 0
+    return desired_state


### PR DESCRIPTION
<html><head></head><body><h1>Add support for device: Cylindrical AC</h1>
<h2>Summary</h2>
<p>This PR adds full support for the <strong>Cylindrical AC</strong> device type, which is currently not recognized by the integration and falls back to a basic remote entity. The Cylindrical AC is functionally very similar to the Split AC but uses slightly different field names in the AWS IoT Thing State for some properties.</p>
<h2>Device Information</h2>
<p>The device identifies itself with <code>device_name: "Cylindrical AC"</code> in the TCL API response. It is a wall-mounted or floor-standing cylindrical air conditioning unit that supports cooling, heating, dehumidification, fan-only, and auto modes.</p>
<h3>Reported fields from device diagnostics</h3>
<p>The following fields are reported by the device in the AWS IoT Thing State:</p>

Field | Example Value | Description
-- | -- | --
powerSwitch | 0 | On/Off toggle
workMode | 4 | Operating mode (0=Auto, 1=Cool, 2=Dehumidify, 3=Fan, 4=Heat)
targetTemperature | 24 | Target temperature in °C
currentTemperature | 19.2 | Current room temperature
targetFahrenheitTemp | 75 | Target temperature in °F
temperatureType | 0 | Temperature unit (0=Celsius, 1=Fahrenheit)
lowerTemperatureLimit | 16 | Minimum settable temperature
upperTemperatureLimit | 31 | Maximum settable temperature
windSpeed7Gear | 0 | Fan speed (7-gear system)
windSpeedAutoSwitch | 1 | Auto fan speed toggle
verticalWind | 1 | Vertical swing toggle
horizontalWind | 1 | Horizontal swing toggle
verticalDirection | 1 | Vertical vane position
horizontalDirection | 1 | Horizontal vane position
sleep | 0 | Sleep mode
beepSwitch | 1 | Beep on/off
screen | 1 | Display on/off
AIECOSwitch | 1 | AI ECO mode
healthy | 0 | Healthy mode
antiMoldew | 0 | Anti-mold drying
antiDirectBlow | 0 | Anti-direct-blow
generatorMode | 0 | Generator mode
internalUnitCoilTemperature | 20 | Internal coil temperature sensor
externalUnitTemperature | 15 | External unit temperature sensor
selfCleanStatus | 6 | Self-clean status
errorCode | [] | Error codes
capabilities | [7,8,9,11,12,13,23,31,33,34,36,39,40,42,46,48,51] | Device capabilities


<p>Additionally, the Cylindrical AC does <strong>not</strong> report the following fields that the Split AC has: <code>ECO</code>, <code>turbo</code>, <code>silenceSwitch</code>, <code>softWind</code>, <code>highTemperatureWind</code>, <code>windSpeed</code>.</p>
<h2>Changes</h2>
<h3>New file</h3>
<p><strong><code>tcl_device_cylindrical_ac.py</code></strong> — Device data class, stored data initialization, and mode-change handler for the Cylindrical AC. Tailored to the exact fields reported by this device type.</p>
<h3>Modified files</h3>
<p><strong><code>device_types.py</code></strong> — Added <code>CYLINDRICAL_AC = "Cylindrical AC"</code> to the <code>DeviceTypeEnum</code>, added <code>"Cylindrical AC"</code> to the <code>known_device_types</code> list in <code>is_implemented_by_integration()</code>, and added a new <code>elif</code> branch in <code>calculateDeviceType()</code> that returns <code>DeviceTypeEnum.CYLINDRICAL_AC</code>.</p>
<p><strong><code>device_features.py</code></strong> — Added a new <code>case DeviceTypeEnum.CYLINDRICAL_AC:</code> block in <code>getSupportedFeatures()</code> that defines the supported features for this device type, including dynamic feature detection based on reported properties and capabilities.</p>
<p><strong><code>device.py</code></strong> — Added the import for the new device module and added <code>DeviceTypeEnum.CYLINDRICAL_AC</code> handling in three places: the device data instantiation (<code>match self.device_type</code>), the <code>get_device_storage()</code> function, and the <code>get_desired_state_for_mode_change()</code> function.</p>
<p><strong><code>climate.py</code></strong> — Extended the climate handler type check to treat <code>CYLINDRICAL_AC</code> the same as <code>SPLIT_AC</code> (using the <code>"SplitAc"</code> handler type).</p>
<h2>Testing</h2>
<p>Tested with a real Cylindrical AC device. After the changes, the device is correctly recognized and exposes the following entities in Home Assistant:</p>
<ul>
<li>Climate entity with full HVAC mode support (Auto, Cool, Heat, Dry, Fan)</li>
<li>Temperature control with correct min/max limits (16–31 °C)</li>
<li>Fan speed control (7-gear system)</li>
<li>Vertical and horizontal air direction selectors</li>
<li>Switches for power, beep, screen, AI ECO, healthy mode, sleep, and drying</li>
<li>Sensors for current temperature, external unit temperature, and internal coil temperature</li>
</ul></body></html>