### PR TITLE
Fix and issue causing Portable AC to fail

### DIFF
--- a/custom_components/tcl_home_unofficial/device_enums.py
+++ b/custom_components/tcl_home_unofficial/device_enums.py
@@ -212,7 +212,7 @@ class PortableWind4ValueSeedEnum(StrEnum):
 
 
 def getPortableWind4ValueSeed(
-    wind_speed: int, has_auto_mode: bool
+    wind_speed: int, has_auto_mode: bool = False 
 ) -> PortableWind4ValueSeedEnum:
     if has_auto_mode:
         match wind_speed:

--- a/custom_components/tcl_home_unofficial/device_rn_probe.py
+++ b/custom_components/tcl_home_unofficial/device_rn_probe.py
@@ -201,7 +201,7 @@ def process_bundle_text(bundle_text: str) -> ProbeData:
     return probe_data
 
 
-def parse_fan_speed_mapping(bundle_text: str) -> list[str] | None:
+def parse_fan_speed_mapping(bundle_text: str) -> list[str]:
     """Parse FAN_SPEED_* new Map([...]) tokens from bundle text and return ordered list.
 
     Looks for an explicit new Map([...]) containing entries like ['FAN_SPEED_AUTO',0].
@@ -216,4 +216,4 @@ def parse_fan_speed_mapping(bundle_text: str) -> list[str] | None:
         entries = entry_pattern.findall(m.group(1))
         if entries and any(tok.startswith("FAN_SPEED_") for tok, _ in entries):
             return [tok for tok, _ in entries]
-    return None
+    return []


### PR DESCRIPTION
There are 2 fixes (2 commits) in this PR as there are 2 issues in #39 that are linked but different. It's unknown if either resolve the original posters issue.

### Fix in 2447ff1c79e17b470826b8d5ce8d24a7d5d09f8f

This should resolve issues attached to this [comment ](https://github.com/nemesa/ha-tcl-home-unofficial-integration/issues/39#issuecomment-3368154248) in #39 

There would be an Exception that was caught while getting the capabilities in `device.py` causing any TCL devices with an empty fan_speed_mapping map in the aws data  dump to fail to load.


The data from AWS:
<img width="188" height="49" alt="image" src="https://github.com/user-attachments/assets/21bc854f-94f5-4492-b01c-dcf7bd880e41" />

The issue was that parse_fan_speed_mapping in `device_rn_probe.py` would return None (and was typed to) but the locations that used `fan_speed_mapping` couldn't handle the None.

For example in device_features.py:375 it treats `rn_probe_data.get("fan_speed_mapping", [])` as always a List and never handles a None. Since an empty List is essentially `None` with respect to this context, just returning an empty list is the smallest change that also makes sense.

The Exception that killed it for most people was on line device_features.py:377 where it would try `<str> in <None>`

Fix in ### 494a0bcc7bb42ff6956bd9b77702c86951ecea72:

This resolves this [comment ](https://github.com/nemesa/ha-tcl-home-unofficial-integration/issues/39#issuecomment-3262008141) specifically ` for climate: getPortableWind4ValueSeed() missing 1 required positional argument: 'has_auto_mode'`

This issue was introduced in a9593256d8548e0720eaf95576845e4c4ee2db7d when climate.py didn't specifiy the 2nd param `has_auto_mode`. I've added a default to has_auto_mode in getPortableWind4ValueSeed because i cannot test or confirm what has_auto_mode should be in climate.py. 


Testing:

I tested that the `NoneType` issue is gone, and that the integration loads and continues to work.

