### PR TITLE
Portable AC: fix 2-speed fan crash, add Turbo, model-specific gating

### DIFF
--- a/custom_components/tcl_home_unofficial/__init__.py
+++ b/custom_components/tcl_home_unofficial/__init__.py
@@ -16,6 +16,7 @@ from .config_entry import (
 )
 from .coordinator import IotDeviceCoordinator
 from .device import Device, get_device_storage, store_rn_prode_data
+from .device_features import PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS
 from .device_types import is_implemented_by_integration
 from .device_rn_probe import fetch_and_parse_config
 from .data_storage import (
@@ -107,7 +108,27 @@ async def async_setup_entry(
             use_fakes=safe_get_value(internal_settings, "fake.use_fake_data", False)
         )
         storage_data = await store_rn_prode_data(hass, device_id, probe_result)
-        
+
+        # Models that never report energy / work-time to the cloud: disable the
+        # polling entirely so we don't make pointless hourly requests. Marking
+        # init_done also skips the one-time probe below.
+        if thing.product_key in PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS:
+            need_save = False
+            for path in (
+                "non_user_config.power_consumption.enabled",
+                "non_user_config.work_time.enabled",
+            ):
+                storage_data, changed = safe_set_value(storage_data, path, False, True)
+                need_save = need_save or changed
+            for path in (
+                "non_user_config.power_consumption.init_done",
+                "non_user_config.work_time.init_done",
+            ):
+                storage_data, changed = safe_set_value(storage_data, path, True, True)
+                need_save = need_save or changed
+            if need_save:
+                storage_data = await set_stored_data(hass, device_id, storage_data)
+
         power_consumption_init_done= safe_get_value(storage_data, "non_user_config.power_consumption.init_done", False)
         if configData.verbose_setup_logging:
             _LOGGER.info("_init_.power_consumption_init_done - %s",power_consumption_init_done)

--- a/custom_components/tcl_home_unofficial/climate.py
+++ b/custom_components/tcl_home_unofficial/climate.py
@@ -20,12 +20,14 @@ from .device_enums import (
     LeftAndRightAirSupplyVectorEnum,
     ModeEnum,
     PortableWind4ValueSeedEnum,
+    PortableWindSeedEnum,
     UpAndDownAirSupplyVectorEnum,
     WindowAcWindSeedEnum,
     WindSeed7GearEnum,
     WindSeedEnum,
     getLeftAndRightAirSupplyVector,
     getPortableWind4ValueSeed,
+    getPortableWindSeed,
     getUpAndDownAirSupplyVector,
     getWindowAcWindSeed,
     getWindSeed7Gear,
@@ -51,6 +53,9 @@ def get_fan_speed_feature(device: Device) -> str:
 
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
         return DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED
+
+    if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
+        return DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED
     return DeviceFeatureEnum.SELECT_WIND_SPEED
 
 
@@ -60,7 +65,19 @@ def get_current_fan_speed_fn(device: Device) -> str:
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return getWindowAcWindSeed(device.data.wind_speed)
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
-        return getPortableWind4ValueSeed(device.data.wind_speed)
+        return getPortableWind4ValueSeed(
+            device.data.wind_speed,
+            has_auto_mode=(
+                DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
+            ),
+        )
+    if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
+        return getPortableWindSeed(
+            device.data.wind_speed,
+            has_auto_mode=(
+                DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
+            ),
+        )
     return getWindSpeed(
         wind_speed=device.data.wind_speed,
         turbo=device.data.turbo,
@@ -75,6 +92,8 @@ def get_options_fan_speed(device: Device) -> list[str]:
         return [e.value for e in WindowAcWindSeedEnum]
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
         return [e.value for e in PortableWind4ValueSeedEnum]
+    if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
+        return [e.value for e in PortableWindSeedEnum]
     return [e.value for e in WindSeedEnum]
 
 

--- a/custom_components/tcl_home_unofficial/climate.py
+++ b/custom_components/tcl_home_unofficial/climate.py
@@ -65,12 +65,7 @@ def get_current_fan_speed_fn(device: Device) -> str:
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return getWindowAcWindSeed(device.data.wind_speed)
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
-        return getPortableWind4ValueSeed(
-            device.data.wind_speed,
-            has_auto_mode=(
-                DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
-            ),
-        )
+        return getPortableWind4ValueSeed(device.data.wind_speed)
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
         return getPortableWindSeed(
             device.data.wind_speed,
@@ -91,14 +86,7 @@ def get_options_fan_speed(device: Device) -> list[str]:
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return [e.value for e in WindowAcWindSeedEnum]
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
-        options = [
-            PortableWind4ValueSeedEnum.LOW.value,
-            PortableWind4ValueSeedEnum.MEDIUM.value,
-            PortableWind4ValueSeedEnum.HIGH.value,
-        ]
-        if DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features:
-            options.append(PortableWind4ValueSeedEnum.AUTO.value)
-        return options
+        return [e.value for e in PortableWind4ValueSeedEnum]
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
         options = [
             PortableWindSeedEnum.LOW.value,

--- a/custom_components/tcl_home_unofficial/climate.py
+++ b/custom_components/tcl_home_unofficial/climate.py
@@ -91,9 +91,22 @@ def get_options_fan_speed(device: Device) -> list[str]:
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return [e.value for e in WindowAcWindSeedEnum]
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
-        return [e.value for e in PortableWind4ValueSeedEnum]
+        options = [
+            PortableWind4ValueSeedEnum.LOW.value,
+            PortableWind4ValueSeedEnum.MEDIUM.value,
+            PortableWind4ValueSeedEnum.HIGH.value,
+        ]
+        if DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features:
+            options.append(PortableWind4ValueSeedEnum.AUTO.value)
+        return options
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
-        return [e.value for e in PortableWindSeedEnum]
+        options = [
+            PortableWindSeedEnum.LOW.value,
+            PortableWindSeedEnum.HIGH.value,
+        ]
+        if DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features:
+            options.append(PortableWindSeedEnum.AUTO.value)
+        return options
     return [e.value for e in WindSeedEnum]
 
 

--- a/custom_components/tcl_home_unofficial/climate.py
+++ b/custom_components/tcl_home_unofficial/climate.py
@@ -45,6 +45,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_fan_speed_feature(device: Device) -> str:
+    # Pick the wind-speed feature that drives the climate entity's fan modes.
+    # The order matters: each device type exposes exactly one of these variants.
     if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in device.supported_features:
         return DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR
 
@@ -54,18 +56,29 @@ def get_fan_speed_feature(device: Device) -> str:
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
         return DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED
 
+    # Portable ACs reported via the RN probe as 2-speed (Low/High[/Auto]) use the
+    # SELECT_PORTABLE_WIND_SPEED variant. Without this branch they would fall
+    # through to the generic SELECT_WIND_SPEED below, whose handlers read
+    # turbo / silence_switch - fields that do not exist on the portable AC data
+    # model (TCL_PortableAC_DeviceData) and would raise AttributeError.
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
         return DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED
     return DeviceFeatureEnum.SELECT_WIND_SPEED
 
 
 def get_current_fan_speed_fn(device: Device) -> str:
+    # Translate the raw windSpeed value into the human-readable fan mode that the
+    # climate card shows, using the mapping that matches the device's variant.
     if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in device.supported_features:
         return getWindSeed7Gear(device.data.wind_speed_7_gear)
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return getWindowAcWindSeed(device.data.wind_speed)
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
         return getPortableWind4ValueSeed(device.data.wind_speed)
+    # 2-speed portable AC. has_auto_mode shifts the windSpeed->label mapping
+    # (e.g. with Auto: 0=Auto/1=Low/2=High; without: 0=Low/1=High), so it must
+    # match what the separate Wind Speed select entity reports. Auto only exists
+    # when the device actually has an Auto mode (signalled by MODE_AC_AUTO).
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
         return getPortableWindSeed(
             device.data.wind_speed,
@@ -73,6 +86,8 @@ def get_current_fan_speed_fn(device: Device) -> str:
                 DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
             ),
         )
+    # Generic split-AC style wind speed. Only reached for non-portable devices,
+    # whose data model has the turbo / silence_switch fields.
     return getWindSpeed(
         wind_speed=device.data.wind_speed,
         turbo=device.data.turbo,
@@ -81,12 +96,17 @@ def get_current_fan_speed_fn(device: Device) -> str:
 
 
 def get_options_fan_speed(device: Device) -> list[str]:
+    # The list of selectable fan modes for the climate entity, per variant.
     if DeviceFeatureEnum.SELECT_WIND_SPEED_7_GEAR in device.supported_features:
         return [e.value for e in WindSeed7GearEnum]
     if DeviceFeatureEnum.SELECT_WINDOW_AS_WIND_SPEED in device.supported_features:
         return [e.value for e in WindowAcWindSeedEnum]
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
         return [e.value for e in PortableWind4ValueSeedEnum]
+    # 2-speed portable AC: offer Low/High, and only add Auto when the device
+    # genuinely supports an Auto mode. Listing every PortableWindSeedEnum value
+    # unconditionally would expose a non-functional "Auto" option on units that
+    # only have Low/High.
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_SPEED in device.supported_features:
         options = [
             PortableWindSeedEnum.LOW.value,

--- a/custom_components/tcl_home_unofficial/device.py
+++ b/custom_components/tcl_home_unofficial/device.py
@@ -90,6 +90,7 @@ class Device:
                                 self.device_type,
                                 aws_thing["state"]["reported"],
                                 self.storage,
+                                self.product_key,
                             )
                         except Exception as e:
                             _LOGGER.error("Error while getSupportedFeatures for device %s: %s",self.device_id,str(e),)

--- a/custom_components/tcl_home_unofficial/device_features.py
+++ b/custom_components/tcl_home_unofficial/device_features.py
@@ -117,6 +117,9 @@ PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS = {
 def getSupportedFeatures(
     device_type: DeviceTypeEnum,aws_thing_state_reported: dict[str, any],device_storage: dict[str, any] | None = None,product_key: str | None = None,
 ) -> list[DeviceFeatureEnum]:
+    # product_key identifies the device MODEL (shared by every unit of the same
+    # model, unlike the per-unit device_id). It is used for model-specific
+    # behaviour - see the PORTABLE_AC_*_PRODUCT_KEYS sets above.
     try:
         capabilities = aws_thing_state_reported.get("capabilities", [])
         has_power_consumption_data = False

--- a/custom_components/tcl_home_unofficial/device_features.py
+++ b/custom_components/tcl_home_unofficial/device_features.py
@@ -99,8 +99,23 @@ def has_property(aws_thing_state_reported: dict[str, any], propertyName: str) ->
     return propertyName in aws_thing_state_reported
 
 
+# Model-specific overrides keyed by TCL product_key.
+# Portable AC models whose physical remote has a Turbo button (max fan + min
+# temperature). The portable AC has no native turbo property, so it is exposed
+# as a switch macro only for these known models.
+PORTABLE_AC_TURBO_PRODUCT_KEYS = {
+    "tIgozLZHRcSBif9W",  # TCL TAC-09CPB/PSLWS
+}
+
+# Portable AC models that do not report energy consumption / work time to the
+# TCL cloud (the API always returns zeros), so those sensors are not created.
+PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS = {
+    "tIgozLZHRcSBif9W",  # TCL TAC-09CPB/PSLWS
+}
+
+
 def getSupportedFeatures(
-    device_type: DeviceTypeEnum,aws_thing_state_reported: dict[str, any],device_storage: dict[str, any] | None = None,
+    device_type: DeviceTypeEnum,aws_thing_state_reported: dict[str, any],device_storage: dict[str, any] | None = None,product_key: str | None = None,
 ) -> list[DeviceFeatureEnum]:
     try:
         capabilities = aws_thing_state_reported.get("capabilities", [])
@@ -433,7 +448,6 @@ def getSupportedFeatures(
                     DeviceFeatureEnum.MODE_AC_COOL,
                     DeviceFeatureEnum.SWITCH_POWER,
                     DeviceFeatureEnum.SWITCH_SLEEP,
-                    DeviceFeatureEnum.SWITCH_PORTABLE_TURBO,
                     DeviceFeatureEnum.SELECT_MODE,
                     DeviceFeatureEnum.NUMBER_TARGET_DEGREE,
                     DeviceFeatureEnum.SENSOR_IS_ONLINE,
@@ -441,9 +455,19 @@ def getSupportedFeatures(
                     DeviceFeatureEnum.USER_CONFIG_SETTINGS_MIN_TEMP,
                     DeviceFeatureEnum.USER_CONFIG_SETTINGS_MAX_TEMP,
                 ]
-                if has_power_consumption_data:
+
+                # Turbo is only exposed for models whose remote has the button.
+                if product_key in PORTABLE_AC_TURBO_PRODUCT_KEYS:
+                    features.append(DeviceFeatureEnum.SWITCH_PORTABLE_TURBO)
+
+                # Skip energy / work-time sensors for models that never report
+                # this data to the cloud (would always show 0).
+                reports_energy = (
+                    product_key not in PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS
+                )
+                if has_power_consumption_data and reports_energy:
                     features.append(DeviceFeatureEnum.SENSOR_POWER_CONSUMPTION_DAILY)
-                if has_work_time_data:
+                if has_work_time_data and reports_energy:
                     features.append(DeviceFeatureEnum.SENSOR_WORK_TIME_DAILY)
 
                 if has_rn_probe_data:

--- a/custom_components/tcl_home_unofficial/device_features.py
+++ b/custom_components/tcl_home_unofficial/device_features.py
@@ -47,6 +47,7 @@ class DeviceFeatureEnum(StrEnum):
     SWITCH_LIGHT_SENSE = "switch.lightSense"
     SWITCH_SWING_WIND = "switch.swingWind"
     SWITCH_SLEEP = "switch.sleep"
+    SWITCH_PORTABLE_TURBO = "switch.portableTurbo"
     SWITCH_8_C_HEATING = "switch.8CHeating"
     SWITCH_SOFT_WIND = "switch.softWind"
     SWITCH_FRESH_AIR = "switch.freshAir"
@@ -432,6 +433,7 @@ def getSupportedFeatures(
                     DeviceFeatureEnum.MODE_AC_COOL,
                     DeviceFeatureEnum.SWITCH_POWER,
                     DeviceFeatureEnum.SWITCH_SLEEP,
+                    DeviceFeatureEnum.SWITCH_PORTABLE_TURBO,
                     DeviceFeatureEnum.SELECT_MODE,
                     DeviceFeatureEnum.NUMBER_TARGET_DEGREE,
                     DeviceFeatureEnum.SENSOR_IS_ONLINE,

--- a/custom_components/tcl_home_unofficial/switch.py
+++ b/custom_components/tcl_home_unofficial/switch.py
@@ -31,9 +31,15 @@ def get_SWITCH_DRYING_name(device: Device) -> str:
 def get_portable_max_wind_speed(device: Device) -> int:
     """Return the windSpeed value that represents the highest fan speed.
 
-    The encoding depends on which portable wind-speed variant the device uses
-    and whether it has an Auto mode (signalled by the presence of swingWind /
-    MODE_AC_AUTO). This mirrors the mappings in select.py.
+    The raw windSpeed value that means "highest" differs per portable variant
+    and by whether the unit has an Auto mode (signalled by the swingWind
+    property / MODE_AC_AUTO feature). These numbers mirror the mappings used in
+    select.py / device_enums.py so Turbo and the Wind Speed select stay in sync:
+
+      4-value with Auto:    0=Auto 1=Low 2=Medium 3=High  -> max = 3
+      4-value without Auto:       0=Low 1=Medium 2=High    -> max = 2
+      2-value with Auto:    0=Auto 1=Low 2=High            -> max = 2
+      2-value without Auto:       0=Low 1=High             -> max = 1
     """
     has_auto = DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
     if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
@@ -42,7 +48,13 @@ def get_portable_max_wind_speed(device: Device) -> int:
 
 
 def get_portable_turbo_is_on(device: Device) -> bool:
-    """Turbo is considered active when the device is at max fan + min temperature."""
+    """Whether the Turbo switch should read as "on".
+
+    There is no native turbo flag on portable ACs, so Turbo is derived: it is
+    "on" when the device currently sits at the maximum fan speed AND the minimum
+    target temperature - exactly the state the Turbo macro applies. This also
+    makes the switch reflect Turbo set from the physical remote.
+    """
     if not device or not device.data:
         return False
     min_temp = safe_get_value(device.storage, "user_config.settings.min_temp", 18)
@@ -143,6 +155,9 @@ class DesiredStateHandlerForSwitch:
                 else:
                     return True
             case DeviceFeatureEnum.SWITCH_PORTABLE_TURBO:
+                # Turbo only makes sense as a cooling boost: it needs the unit
+                # powered on and in Cool mode (min temperature is meaningless in
+                # Fan / Dehumidification). Greyed out otherwise.
                 if self.device and self.device.data and self.device.data.power_switch == 0:
                     return False
                 return mode == ModeEnum.COOL
@@ -346,6 +361,10 @@ class DesiredStateHandlerForSwitch:
             target_temp = min_temp
             wind_speed = max_wind_speed
         else:
+            # Turning Turbo off: restore the remembered pre-turbo values. If none
+            # were stored (e.g. Turbo was engaged from the remote, or storage was
+            # cleared), fall back to the lowest fan speed (0) and the last known
+            # Cool target temperature so we leave the unit in a sane state.
             default_target_temp = safe_get_value(
                 stored_data, "target_temperature.Cool.value", 22
             )
@@ -358,6 +377,8 @@ class DesiredStateHandlerForSwitch:
                 default_target_temp,
             )
 
+        # Set both Celsius and Fahrenheit targets together - the portable AC
+        # firmware tracks both and expects them to stay consistent.
         desired_state = {
             "windSpeed": wind_speed,
             "targetCelsiusDegree": target_temp,
@@ -654,6 +675,11 @@ async def async_setup_entry(
                 )
             )
 
+        # Turbo switch. The feature is only present for portable AC models whose
+        # remote actually has a Turbo button (gated by product_key in
+        # device_features.py), so no extra device-type check is needed here.
+        # DynamicSwitchHandler is used so availability follows is_allowed()
+        # (powered on + Cool mode).
         if DeviceFeatureEnum.SWITCH_PORTABLE_TURBO in device.supported_features:
             switches.append(
                 DynamicSwitchHandler(

--- a/custom_components/tcl_home_unofficial/switch.py
+++ b/custom_components/tcl_home_unofficial/switch.py
@@ -8,6 +8,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .calculations import celsius_to_fahrenheit
 from .config_entry import New_NameConfigEntry
 from .coordinator import IotDeviceCoordinator
 from .data_storage import (get_stored_data, safe_get_value, safe_set_value,
@@ -25,6 +26,30 @@ def get_SWITCH_DRYING_name(device: Device) -> str:
     if device.device_type == DeviceTypeEnum.SPLIT_AC_FRESH_AIR:
         return "Mildewproof Switch"
     return "Drying Switch"
+
+
+def get_portable_max_wind_speed(device: Device) -> int:
+    """Return the windSpeed value that represents the highest fan speed.
+
+    The encoding depends on which portable wind-speed variant the device uses
+    and whether it has an Auto mode (signalled by the presence of swingWind /
+    MODE_AC_AUTO). This mirrors the mappings in select.py.
+    """
+    has_auto = DeviceFeatureEnum.MODE_AC_AUTO in device.supported_features
+    if DeviceFeatureEnum.SELECT_PORTABLE_WIND_4VALUE_SPEED in device.supported_features:
+        return 3 if has_auto else 2
+    return 2 if has_auto else 1
+
+
+def get_portable_turbo_is_on(device: Device) -> bool:
+    """Turbo is considered active when the device is at max fan + min temperature."""
+    if not device or not device.data:
+        return False
+    min_temp = safe_get_value(device.storage, "user_config.settings.min_temp", 18)
+    return (
+        device.data.wind_speed == get_portable_max_wind_speed(device)
+        and device.data.target_temperature == min_temp
+    )
 
 
 class DesiredStateHandlerForSwitch:
@@ -63,6 +88,8 @@ class DesiredStateHandlerForSwitch:
                 return await self.SWITCH_SWING_WIND(value=value)
             case DeviceFeatureEnum.SWITCH_SLEEP:
                 return await self.SWITCH_SLEEP(value=value)
+            case DeviceFeatureEnum.SWITCH_PORTABLE_TURBO:
+                return await self.SWITCH_PORTABLE_TURBO(value=value)
             case DeviceFeatureEnum.SWITCH_AI_ECO:
                 return await self.SWITCH_AI_ECO(value=value)
             case DeviceFeatureEnum.SWITCH_8_C_HEATING:
@@ -115,6 +142,10 @@ class DesiredStateHandlerForSwitch:
                     return False
                 else:
                     return True
+            case DeviceFeatureEnum.SWITCH_PORTABLE_TURBO:
+                if self.device and self.device.data and self.device.data.power_switch == 0:
+                    return False
+                return mode == ModeEnum.COOL
             case DeviceFeatureEnum.SWITCH_ECO:
                 if (
                     mode == ModeEnum.FAN
@@ -279,6 +310,59 @@ class DesiredStateHandlerForSwitch:
         desired_state = {"sleep": value}
         if self.device.device_type == DeviceTypeEnum.PORTABLE_AC:
             desired_state["windSpeed"] = 1 if value == 1 else 2
+        return await self.coordinator.get_aws_iot().async_set_desired_state(
+            self.device.device_id, desired_state
+        )
+
+    async def SWITCH_PORTABLE_TURBO(self, value: int):
+        """Turbo for portable ACs: a macro that mirrors the remote's Turbo button.
+
+        The portable AC has no native turbo property, so enabling it just sets
+        the maximum fan speed together with the minimum target temperature.
+        The previous fan speed / temperature are remembered so they can be
+        restored when Turbo is switched off.
+        """
+        stored_data = await get_stored_data(self.hass, self.device.device_id)
+        min_temp = safe_get_value(stored_data, "user_config.settings.min_temp", 18)
+        max_wind_speed = get_portable_max_wind_speed(self.device)
+
+        if value == 1:
+            # Remember the pre-turbo state, but only when we are not already in
+            # a turbo-equivalent state (so we never overwrite the real values).
+            if not get_portable_turbo_is_on(self.device):
+                stored_data, _ = safe_set_value(
+                    stored_data,
+                    "non_user_config.turbo.prev_wind_speed",
+                    self.device.data.wind_speed,
+                    overwrite_if_exists=True,
+                )
+                stored_data, _ = safe_set_value(
+                    stored_data,
+                    "non_user_config.turbo.prev_target_temperature",
+                    self.device.data.target_temperature,
+                    overwrite_if_exists=True,
+                )
+                await set_stored_data(self.hass, self.device.device_id, stored_data)
+            target_temp = min_temp
+            wind_speed = max_wind_speed
+        else:
+            default_target_temp = safe_get_value(
+                stored_data, "target_temperature.Cool.value", 22
+            )
+            wind_speed = safe_get_value(
+                stored_data, "non_user_config.turbo.prev_wind_speed", 0
+            )
+            target_temp = safe_get_value(
+                stored_data,
+                "non_user_config.turbo.prev_target_temperature",
+                default_target_temp,
+            )
+
+        desired_state = {
+            "windSpeed": wind_speed,
+            "targetCelsiusDegree": target_temp,
+            "targetFahrenheitDegree": celsius_to_fahrenheit(target_temp),
+        }
         return await self.coordinator.get_aws_iot().async_set_desired_state(
             self.device.device_id, desired_state
         )
@@ -567,6 +651,24 @@ async def async_setup_entry(
                     name="Sleep",
                     icon_fn=lambda device: "mdi:sleep",
                     is_on_fn=lambda device: device.data.sleep,
+                )
+            )
+
+        if DeviceFeatureEnum.SWITCH_PORTABLE_TURBO in device.supported_features:
+            switches.append(
+                DynamicSwitchHandler(
+                    hass=hass,
+                    coordinator=coordinator,
+                    device=device,
+                    deviceFeature=DeviceFeatureEnum.SWITCH_PORTABLE_TURBO,
+                    type="PortableTurbo",
+                    name="Turbo",
+                    icon_fn=lambda device: (
+                        "mdi:fan-plus"
+                        if get_portable_turbo_is_on(device)
+                        else "mdi:fan"
+                    ),
+                    is_on_fn=lambda device: get_portable_turbo_is_on(device),
                 )
             )
 


### PR DESCRIPTION
## Summary
Fixes and additions for portable ACs, verified on a TCL TAC-09CPB/PSLWS
(product_key `tIgozLZHRcSBif9W`). Care was taken **not** to change behaviour
for any other device type or model — all model-specific parts are gated by
`product_key`.

### Bug fixes (all 2-speed portable ACs)
- Fix `AttributeError: 'TCL_PortableAC_DeviceData' object has no attribute 'turbo'`
  when setting up the climate entity. Portable ACs mapped to
  `SELECT_PORTABLE_WIND_SPEED` (2-speed Low/High[/Auto]) were not handled in
  climate.py's fan-speed helpers and fell through to the generic split-AC branch,
  which reads `turbo` / `silence_switch` — fields that don't exist on the
  portable data model.
- Don't offer a non-functional "Auto" fan mode in the climate card for 2-speed
  portable ACs without an Auto mode; the option list now matches the Wind Speed
  select entity.
- These only touch the 2-speed portable code path; 4-value portable and other
  device types are unchanged.

### New features, gated by product_key
- **Turbo switch** for portable ACs whose remote has a Turbo button. The
  portable AC has no native turbo property, so it's a macro: max fan speed +
  min target temperature, restoring the previous values when turned off.
  Available in Cool mode while powered on. Gated by
  `PORTABLE_AC_TURBO_PRODUCT_KEYS`.
- **Skip energy / work-time sensors** (and their hourly polling) for models that
  never report this data to the cloud (always 0). Gated by
  `PORTABLE_AC_NO_ENERGY_REPORTING_PRODUCT_KEYS`.

Both lists are keyed by product_key (the model identifier, shared across all
units of a model) and are trivial to extend for other models.

### Testing
Verified on a live TAC-09CPB: crash gone, fan modes correct (Low/High, no Auto),
Turbo works and restores state, energy/work-time sensors removed and polling
stopped. No changes observed for other device types.