### PR TITLE
Fix "Unknown error" on login: force gzip/JSON responses, report errors

### DIFF
--- a/custom_components/tcl_home_unofficial/config_flow.py
+++ b/custom_components/tcl_home_unofficial/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
+import httpx
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -32,6 +33,7 @@ from .const import (
     DOMAIN,
 )
 from .session_manager import SessionManager
+from .tcl import TclApiError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,13 +61,24 @@ async def isUserCanLogIn(hass: HomeAssistant, data: dict[str, Any]) -> dict:
         ),
     )
 
-    await sessionManager.clear_storage()
-    await sessionManager.async_load()
+    try:
+        await sessionManager.clear_storage()
+        await sessionManager.async_load()
 
-    authResult = await sessionManager.async_get_auth_data(allowInvalid=True)
+        authResult = await sessionManager.async_get_auth_data(allowInvalid=True)
+    except httpx.HTTPError:
+        _LOGGER.exception("Could not reach the TCL login service at %s", data["app_login_url"])
+        return {"success": False, "error": "cannot_connect"}
+    except TclApiError:
+        _LOGGER.exception("The TCL login service answered with something unusable")
+        return {"success": False, "error": "cannot_connect"}
+    except Exception:  # noqa: BLE001 - anything else would surface as "Unknown error"
+        _LOGGER.exception("Unexpected error while logging in to the TCL Home account")
+        return {"success": False, "error": "unknown"}
+
     if authResult is not None and authResult.token:
-        return {"success": True}
-    return {"success": False}
+        return {"success": True, "error": None}
+    return {"success": False, "error": "invalid_auth"}
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
@@ -84,7 +97,7 @@ class TclHomeUnofficialConfigFlow(ConfigFlow, domain=DOMAIN):
     _input_data: dict[str, Any] = {}
     _title: str
 
-    _has_invalid_auth: bool = False
+    _login_error: str | None = None
 
     @staticmethod
     @callback
@@ -97,8 +110,8 @@ class TclHomeUnofficialConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         _LOGGER.info("Starting config flow for TCL Home Unofficial integration")
         errors: dict[str, str] = {}
-        if self._has_invalid_auth:
-            errors["base"] = "invalid_auth"
+        if self._login_error:
+            errors["base"] = self._login_error
         user_name = DEFAULT_USER
         user_password = DEFAULT_PW
 
@@ -119,7 +132,7 @@ class TclHomeUnofficialConfigFlow(ConfigFlow, domain=DOMAIN):
             self._input_data = user_input
 
             # Call the next step
-            self._has_invalid_auth = False
+            self._login_error = None
             return await self.async_step_settings_of_app()
 
         return self.async_show_form(
@@ -139,7 +152,7 @@ class TclHomeUnofficialConfigFlow(ConfigFlow, domain=DOMAIN):
 
             canUserLoginResult = await isUserCanLogIn(self.hass, self._input_data)
             if canUserLoginResult["success"] is False:
-                self._has_invalid_auth = True
+                self._login_error = canUserLoginResult.get("error") or "unknown"
                 return await self.async_step_user()
             else:
                 return await self.async_step_settings_of_logs()

--- a/custom_components/tcl_home_unofficial/tcl.py
+++ b/custom_components/tcl_home_unofficial/tcl.py
@@ -13,6 +13,36 @@ from homeassistant.helpers.httpx_client import get_async_client
 
 _LOGGER = logging.getLogger(__name__)
 
+# The TCL gateway compresses the response body with whatever encoding the request
+# advertises. When brotli (or zstd) is advertised the gateway can answer with a body
+# that Home Assistant's httpx has no decoder for, and the still-compressed bytes then
+# fail inside response.json() - which the config flow could only report as
+# "Unknown error". Asking for JSON + gzip keeps every answer decodable.
+JSON_ACCEPT_HEADERS = {
+    "accept": "application/json",
+    "accept-encoding": "gzip",
+}
+
+
+class TclApiError(Exception):
+    """A TCL endpoint answered with something we cannot use."""
+
+
+def parse_json_response(response, context: str) -> dict:
+    """Parse a TCL response body, reporting what actually arrived when it is not JSON."""
+    try:
+        return response.json()
+    except ValueError as err:
+        # UnicodeDecodeError is a ValueError, so an undecodable (still compressed)
+        # body lands here too.
+        raise TclApiError(
+            f"{context}: HTTP {response.status_code} body was not JSON"
+            f" (content-type={response.headers.get('content-type')},"
+            f" content-encoding={response.headers.get('content-encoding')}):"
+            f" {response.content[:200]!r}"
+        ) from err
+
+
 
 def getValue(data: dict, keys: list[str]) -> str:
     """Get value from dictionary with fallback."""
@@ -332,18 +362,35 @@ async def do_account_auth(
         "th_appbulid": "830",
         "user-agent": "Android",
         "content-type": "application/json; charset=UTF-8",
+        **JSON_ACCEPT_HEADERS,
     }
 
     httpx_client = get_async_client(hass)
     response = await httpx_client.post(login_url, json=payload, headers=headers, timeout=15)
 
-    response_obj = response.json()
+    if response.status_code != 200:
+        _LOGGER.error(
+            "TCL-Service.do_account_auth: login failed with HTTP %s: %s",
+            response.status_code,
+            response.text[:500],
+        )
+        return None
+
+    response_obj = parse_json_response(response, "TCL-Service.do_account_auth")
     if verbose_logging:
         _LOGGER.info("TCL-Service.do_account_auth response: %s", response_obj)
-    if response.status_code == 200:
-        authResponse = DoAccountAuthResponse(response_obj)
-        if authResponse.status == 1:
-            return authResponse
+
+    authResponse = DoAccountAuthResponse(response_obj)
+    if authResponse.status == 1:
+        return authResponse
+
+    # TCL answers 200 with a status/msg pair when it refuses the credentials,
+    # e.g. {"status": 3, "msg": "Username is invalid"}.
+    _LOGGER.error(
+        "TCL-Service.do_account_auth: TCL refused the login (status=%s, msg=%s)",
+        getValue(response_obj, ["status"]),
+        getValue(response_obj, ["msg", "message"]),
+    )
     return None
 
 
@@ -362,16 +409,31 @@ async def get_cloud_urls(
     headers = {
         "user-agent": "Android",
         "content-type": "application/json; charset=UTF-8",
+        **JSON_ACCEPT_HEADERS,
     }
 
     httpx_client = get_async_client(hass)
     response = await httpx_client.post(cloud_urls, json=payload, headers=headers, timeout=15)
-    response_obj = response.json()
+    if response.status_code != 200:
+        _LOGGER.error(
+            "TCL-Service.get_cloud_urls: failed with HTTP %s: %s",
+            response.status_code,
+            response.text[:500],
+        )
+        return None
+
+    response_obj = parse_json_response(response, "TCL-Service.get_cloud_urls")
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_cloud_urls response: %s", response_obj)
-    if response.status_code == 200:
-        return CloudUrlsResponse(response_obj)
-    return None
+
+    cloudUrls = CloudUrlsResponse(response_obj)
+    if cloudUrls.data.cloud_url is None:
+        # Without cloud_url every later call would be built against "None/v3/...".
+        raise TclApiError(
+            f"TCL-Service.get_cloud_urls: no cloud_url in the response"
+            f" (code={cloudUrls.code}, message={cloudUrls.message})"
+        )
+    return cloudUrls
 
 
 async def refreshTokens(
@@ -395,17 +457,23 @@ async def refreshTokens(
     headers = {
         "user-agent": "Android",
         "content-type": "application/json; charset=UTF-8",
-        "accept-encoding": "gzip, deflate, br",
+        **JSON_ACCEPT_HEADERS,
     }
 
     httpx_client = get_async_client(hass)
     response = await httpx_client.post(url, json=payload, headers=headers, timeout=15)
-    response_obj = response.json()
+    if response.status_code != 200:
+        _LOGGER.error(
+            "TCL-Service.refreshTokens: failed with HTTP %s: %s",
+            response.status_code,
+            response.text[:500],
+        )
+        return None
+
+    response_obj = parse_json_response(response, "TCL-Service.refreshTokens")
     if verbose_logging:
         _LOGGER.info("TCL-Service.refreshTokens response: %s", response_obj)
-    if response.status_code == 200:
-        return RefreshTokensResponse(response_obj)
-    return None
+    return RefreshTokensResponse(response_obj)
 
 
 async def get_aws_credentials(
@@ -429,16 +497,23 @@ async def get_aws_credentials(
         "User-agent": "aws-sdk-android/2.22.6 Linux/6.1.23-android14-4-00257-g7e35917775b8-ab9964412 Dalvik/2.1.0/0 en_US",
         "X-Amz-Target": "AWSCognitoIdentityService.GetCredentialsForIdentity",
         "content-type": "application/x-amz-json-1.1",
+        "accept-encoding": "gzip",
     }
 
     httpx_client = get_async_client(hass)
     response = await httpx_client.post(url, json=payload, headers=headers, timeout=15)
-    response_obj = response.json()
+    if response.status_code != 200:
+        _LOGGER.error(
+            "TCL-Service.get_aws_credentials: failed with HTTP %s: %s",
+            response.status_code,
+            response.text[:500],
+        )
+        return None
+
+    response_obj = parse_json_response(response, "TCL-Service.get_aws_credentials")
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_aws_credentials response: %s", response_obj)
-    if response.status_code == 200:
-        return GetAwsCredentialsResponse(response_obj)
-    return None
+    return GetAwsCredentialsResponse(response_obj)
 
 
 async def get_things(
@@ -469,7 +544,7 @@ async def get_things(
         "sign": sign,
         "user-agent": "Android",
         "content-type": "application/json; charset=UTF-8",
-        "accept-encoding": "gzip, deflate, br",
+        **JSON_ACCEPT_HEADERS,
     }    
 
     httpx_client = get_async_client(hass)
@@ -477,7 +552,7 @@ async def get_things(
     response = await httpx_client.post(url, json={}, headers=headers, timeout=15)
     if response.status_code != 200:
         raise Exception("Error at get_things: " + response.text)
-    response_obj = response.json()
+    response_obj = parse_json_response(response, "TCL-Service.get_things")
     # _LOGGER.info("TCL-Service.get_things: %s", response_obj)
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_things response: %s", response_obj)
@@ -517,7 +592,7 @@ async def get_work_time(
         "sign": sign,
         "user-agent": "Android",
         "appversion": "5.4.1",
-        "accept-encoding": "gzip, deflate, br",
+        **JSON_ACCEPT_HEADERS,
         "accept-language": "en",
         "accesstoken": saas_token,        
     }    
@@ -527,7 +602,7 @@ async def get_work_time(
     response = await httpx_client.get(url, headers=headers, timeout=15)
     if response.status_code != 200:
         raise Exception("Error at get_work_time: " + response.text)
-    response_obj = response.json()
+    response_obj = parse_json_response(response, "TCL-Service.get_work_time")
     # _LOGGER.info("TCL-Service.get_work_time: %s", response_obj)
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_work_time response: %s", response_obj)
@@ -567,7 +642,7 @@ async def get_energy_consumption(
         "sign": sign,
         "user-agent": "Android",
         "appversion": "5.4.1",
-        "accept-encoding": "gzip, deflate, br",
+        **JSON_ACCEPT_HEADERS,
         "accept-language": "en",
         "accesstoken": saas_token,   
     }    
@@ -577,7 +652,7 @@ async def get_energy_consumption(
     response = await httpx_client.get(url, headers=headers, timeout=15)
     if response.status_code != 200:
         raise Exception("Error at get_energy_consumption: " + response.text)
-    response_obj = response.json()
+    response_obj = parse_json_response(response, "TCL-Service.get_energy_consumption")
     # _LOGGER.info("TCL-Service.get_energy_consumption: %s", response_obj)
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_energy_consumption response: %s", response_obj)
@@ -634,7 +709,7 @@ async def get_config(
         "sign": sign,
         "user-agent": "Android",
         "content-type": "application/json; charset=UTF-8",
-        "accept-encoding": "gzip, deflate, br",
+        **JSON_ACCEPT_HEADERS,
     }
 
     httpx_client = get_async_client(hass)
@@ -648,7 +723,7 @@ async def get_config(
             )
         return None
 
-    resp_json = response.json()
+    resp_json = parse_json_response(response, "TCL-Service.get_config")
     if verbose_logging:
         _LOGGER.info("TCL-Service.get_config response: %s", resp_json)
 


### PR DESCRIPTION
Two independent problems made a failed login show up as Home Assistant's generic "Unknown error occurred" dialog with no usable detail in the UI.

1. Five TCL calls advertised "accept-encoding: gzip, deflate, br". The TCL gateway compresses the body with whatever encoding the request offers, so it can answer with brotli; when the httpx in a given HA install has no brotli decoder it passes the raw bytes through and response.json() dies with a UnicodeDecodeError. Login and get_cloud_urls sent no accept-encoding at all and inherited httpx's default, with the same exposure. All TCL calls now send "accept: application/json" and "accept-encoding: gzip", which is always decodable. Reported upstream in #91, where the same header change was confirmed to fix login, refresh_tokens and get_things.

2. isUserCanLogIn() had no exception handling, so any error other than TCL rejecting the credentials escaped the config flow step as a 500 and the frontend could only render it as "Unknown error". It now maps httpx and TCL API failures to cannot_connect, anything unexpected to unknown, and logs the traceback in both cases. _has_invalid_auth becomes _login_error so the form shows which of the three actually happened; all three strings already exist in translations/en.json.

Also in tcl.py, while fixing the parsing path:

- Add TclApiError and parse_json_response(), which reports the status code, content-type, content-encoding and first 200 raw bytes instead of raising a bare decode error. All response parsing goes through it.
- Check response.status_code before parsing JSON. The checks ran after the .json() call, so a non-JSON error page crashed before the status check could return None.
- Log TCL's own rejection message on a refused login, e.g. status=3, msg=Username is invalid.
- Raise a clear error in get_cloud_urls when cloud_url is missing from the response, instead of letting later calls be built against the URL "None/v3/auth/refresh_tokens".